### PR TITLE
Add MOI wrapper for SAT solver

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,18 @@ authors = ["David P. Sanders <dpsanders@gmail.com> and contributors"]
 version = "0.1.0"
 
 [deps]
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
+MathOptInterface = "0.9.22"
+JuMP = "0.21.8"
 ModelingToolkit = "4.3"
 julia = "1"
 
 [extras]
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["JuMP", "Test"]

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1,0 +1,56 @@
+import MathOptInterface
+const MOI = MathOptInterface
+
+mutable struct Optimizer{T} <: MOI.AbstractOptimizer
+    problem::SATProblem
+    status::Symbol
+    results::Vector{Int}
+end
+const NOT_CALLED = :notcalled
+function Optimizer{T}() where {T}
+    return Optimizer{T}(SATProblem(0, Vector{Int}[]), NOT_CALLED, Int[])
+end
+# JuMP will expects `VariablePrimal` to return `Float64`
+Optimizer() = Optimizer{Float64}()
+function MOI.empty!(model::Optimizer)
+    model.problem.num_variables = 0
+    empty!(model.problem.clauses)
+    model.status = NOT_CALLED
+    empty!(model.results)
+end
+function MOI.is_empty(model::Optimizer)
+    return iszero(model.problem.num_variables) && isempty(model.problem.clauses)
+end
+MOI.supports_add_constrained_variable(::Optimizer, ::Type{MOI.ZeroOne}) = true
+function MOI.add_constrained_variable(model::Optimizer, ::MOI.ZeroOne)
+    model.problem.num_variables += 1
+    id = model.problem.num_variables
+    return MOI.VariableIndex(id), MOI.ConstraintIndex{MOI.SingleVariable,MOI.ZeroOne}(id)
+end
+struct CNF <: MOI.AbstractVectorSet
+    not::Vector{Bool}
+end
+MOI.dimension(set::CNF) = length(set.not)
+Base.copy(set::CNF) = CNF(Base.copy(set.not))
+_not(id::Int, not::Bool) = not ? -id : id
+MOI.supports_constraint(::Optimizer, ::Type{MOI.VectorOfVariables}, ::Type{CNF}) = true
+function MOI.add_constraint(model::Optimizer, func::MOI.VectorOfVariables, set::CNF)
+    clause = Int[_not(func.variables[i].value, set.not[i]) for i in eachindex(set.not)]
+    push!(model.problem, clause)
+    return MOI.ConstraintIndex{typeof(func),typeof(set)}(length(model.problem.clauses))
+end
+function MOI.optimize!(model::Optimizer)
+    model.status, model.results = solve(model.problem)
+end
+const TERM = Dict(NOT_CALLED => MOI.OPTIMIZE_NOT_CALLED, :sat => MOI.OPTIMAL, :unsat => MOI.INFEASIBLE, :unknown => MOI.TIME_LIMIT)
+MOI.get(model::Optimizer, ::MOI.TerminationStatus) = TERM[model.status]
+MOI.get(model::Optimizer, ::MOI.ResultCount) = model.status == :sat ? 1 : 0
+function MOI.get(model::Optimizer, attr::MOI.PrimalStatus)
+    if 1 <= attr.N <= MOI.get(model, MOI.ResultCount())
+        return MOI.FEASIBLE_POINT
+    else
+        return MOI.NO_SOLUTION
+    end
+end
+MOI.get(model::Optimizer, ::MOI.DualStatus) = MOI.NO_SOLUTION
+MOI.get(model::Optimizer, ::MOI.VariablePrimal, vi::MOI.VariableIndex) = model.results[vi.value] > 0

--- a/src/SatisfiabilityInterface.jl
+++ b/src/SatisfiabilityInterface.jl
@@ -13,5 +13,6 @@ include("model.jl")
 include("sat_problem.jl")
 include("solver.jl")
 include("symbolic_problem.jl")
+include("MOI_wrapper.jl")
 
 end

--- a/src/sat_problem.jl
+++ b/src/sat_problem.jl
@@ -10,7 +10,7 @@ Input:
 """SAT problem represented numerically in DIMACS-CNF form:
 clauses are integer vectors with negative numbers indicating negated literals
 """
-struct SATProblem
+mutable struct SATProblem
     num_variables::Int
     clauses::Vector{Vector{Int}} 
 end

--- a/test/JuMP.jl
+++ b/test/JuMP.jl
@@ -1,0 +1,20 @@
+using JuMP, SatisfiabilityInterface
+
+@testset "JuMP" begin
+    model = JuMP.Model(SatisfiabilityInterface.Optimizer{Bool})
+    @variable(model, x, Bin)
+    @variable(model, y, Bin)
+    @variable(model, z, Bin)
+    @constraint(model, [x, y, z] in SatisfiabilityInterface.CNF([true, true, true]))
+    @constraint(model, [x, y, z] in SatisfiabilityInterface.CNF([false, true, true]))
+    @constraint(model, [x, y]    in SatisfiabilityInterface.CNF([false, false]))
+    @constraint(model, [y, z]    in SatisfiabilityInterface.CNF([false, false]))
+    @constraint(model, [x, z]    in SatisfiabilityInterface.CNF([true, false]))
+    optimize!(model)
+    @test raw_status(model) == "sat"
+    @test termination_status(model) == MOI.OPTIMAL
+    @test primal_status(model) == MOI.FEASIBLE_POINT
+    @test value(x) == 0.0
+    @test value(y) == 1.0
+    @test value(z) == 0.0
+end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -1,0 +1,21 @@
+import MathOptInterface
+const MOI = MathOptInterface
+
+@testset "MOI wrapper" begin
+    model = SatisfiabilityInterface.Optimizer{Bool}()
+    x = MOI.add_constrained_variable(model, MOI.ZeroOne())
+    y = MOI.add_constrained_variable(model, MOI.ZeroOne())
+    z = MOI.add_constrained_variable(model, MOI.ZeroOne())
+    MOI.add_constraint(model, MOI.VectorOfVariables([x, y, z]), SatisfiabilityInterface.CNF([true, true, true]))
+    MOI.add_constraint(model, MOI.VectorOfVariables([x, y, z]), SatisfiabilityInterface.CNF([false, true, true]))
+    MOI.add_constraint(model, MOI.VectorOfVariables([x, y]),    SatisfiabilityInterface.CNF([false, false]))
+    MOI.add_constraint(model, MOI.VectorOfVariables([y, z]),    SatisfiabilityInterface.CNF([false, false]))
+    MOI.add_constraint(model, MOI.VectorOfVariables([x, z]),    SatisfiabilityInterface.CNF([true, false]))
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.RawStatusString()) == "sat"
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
+    @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+    @test !MOI.get(model, MOI.VariablePrimal(), x)
+    @test MOI.get(model, MOI.VariablePrimal(), y)
+    @test !MOI.get(model, MOI.VariablePrimal(), z)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ using Test
 
     include("graph_colouring.jl")
     include("sudoku.jl")
+    include("MOI_wrapper.jl")
+    include("JuMP.jl")
 
 end
 


### PR DESCRIPTION
Adds an MOI wrapper to allow the use of the SAT solver through MOI (and hence through JuMP)