### PR TITLE
Add CryptoMiniSat_jll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.6' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /Manifest.toml
+*.cnf

--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,15 @@ authors = ["David P. Sanders <dpsanders@gmail.com> and contributors"]
 version = "0.1.0"
 
 [deps]
-MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+CryptoMiniSat_jll = "cf02a7a8-8cd0-5932-97be-477f95a4d9ce"
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+ReversePropagation = "527681c1-8309-4d3f-8790-caf822a419ba"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
-MathOptInterface = "0.9.22"
 JuMP = "0.21.8"
+MathOptInterface = "0.9.22"
 Symbolics = "1"
 julia = "1"
 

--- a/src/SatisfiabilityInterface.jl
+++ b/src/SatisfiabilityInterface.jl
@@ -3,7 +3,8 @@ module SatisfiabilityInterface
 using Symbolics
 using Symbolics: Variable, Sym
 using Symbolics: Assignment, get_variables, operation, arguments, value, istree
-
+using CryptoMiniSat_jll
+using ReversePropagation
 # using ReversePropagation
 
 export DiscreteVariable, ConstraintSatisfactionProblem, DiscreteCSP, SymbolicSATProblem, SATProblem


### PR DESCRIPTION
So this will require some modifications since I still needed ReversePropagation to run anything. But if I add ReversePropagation back this runs as expected. It'd be great to figure that out, get this merged, then I can work on Preferences.jl to allow different CryptoMinisat binaries and then define a good interface that individual solver packages can use via ccall rather than cmd.

E: Preferences should probably be in a CryptoMinisat.jl that implements this package's interface rather.